### PR TITLE
Fix PDF download layout issues in all templates

### DIFF
--- a/components/resume/templates/ChronologicalTemplate.tsx
+++ b/components/resume/templates/ChronologicalTemplate.tsx
@@ -12,7 +12,7 @@ const ChronologicalTemplate: React.FC<{ data: ResumeData }> = ({ data }) => {
     );
 
     return (
-        <div className="h-full bg-white font-sans text-gray-800 text-sm p-10">
+        <div className="bg-white font-sans text-gray-800 text-sm p-10">
             <header className="mb-8">
                 <h1 className="text-4xl font-bold tracking-tight">{personalInfo.fullName}</h1>
                 <p className="text-xl text-gray-600 mt-1">{personalInfo.jobTitle}</p>

--- a/components/resume/templates/ClassicTemplate.tsx
+++ b/components/resume/templates/ClassicTemplate.tsx
@@ -16,7 +16,7 @@ const ClassicTemplate: React.FC<TemplateProps> = ({ data }) => {
     ].filter(Boolean);
 
     return (
-        <div className="h-full bg-white p-8 font-serif text-gray-800 text-sm">
+        <div className="bg-white p-8 font-serif text-gray-800 text-sm">
             {/* Header */}
             <header className="text-center mb-6">
                 <h1 className="text-3xl font-bold tracking-wider uppercase">{personalInfo.fullName}</h1>

--- a/components/resume/templates/CompactTemplate.tsx
+++ b/components/resume/templates/CompactTemplate.tsx
@@ -12,7 +12,7 @@ const CompactTemplate: React.FC<{ data: ResumeData }> = ({ data }) => {
     );
 
     return (
-        <div className="h-full flex font-sans bg-white text-gray-800 text-sm">
+        <div className="flex font-sans bg-white text-gray-800 text-sm">
             {/* Left Column (Sidebar) */}
             <aside className="w-1/3 bg-gray-50 p-6">
                 <header className="mb-8">

--- a/components/resume/templates/CorporateTemplate.tsx
+++ b/components/resume/templates/CorporateTemplate.tsx
@@ -12,7 +12,7 @@ const CorporateTemplate: React.FC<{ data: ResumeData }> = ({ data }) => {
     );
 
     return (
-        <div className="h-full bg-white p-10 font-sans text-gray-800 text-sm">
+        <div className="bg-white p-10 font-sans text-gray-800 text-sm">
             <header className="text-center mb-8">
                 <h1 className="text-4xl font-serif font-bold tracking-wider">{personalInfo.fullName}</h1>
                 <p className="text-lg font-light text-gray-700 mt-1">{personalInfo.jobTitle}</p>

--- a/components/resume/templates/CreativeTemplate.tsx
+++ b/components/resume/templates/CreativeTemplate.tsx
@@ -16,7 +16,7 @@ const CreativeTemplate: React.FC<TemplateProps> = ({ data }) => {
     );
 
     return (
-        <div className="h-full bg-white p-8 font-sans text-gray-800 text-sm">
+        <div className="bg-white p-8 font-sans text-gray-800 text-sm">
             {/* Header */}
             <header className="flex justify-between items-center mb-8 pb-4 border-b-2 border-brand-secondary">
                 <div>

--- a/components/resume/templates/ExecutiveTemplate.tsx
+++ b/components/resume/templates/ExecutiveTemplate.tsx
@@ -15,7 +15,7 @@ const ExecutiveTemplate: React.FC<TemplateProps> = ({ data }) => {
     ].filter(Boolean);
 
     return (
-        <div className="h-full bg-white p-10 font-serif text-gray-800 text-base">
+        <div className="bg-white p-10 font-serif text-gray-800 text-base">
             {/* Header */}
             <header className="text-center mb-8">
                 <h1 className="text-4xl font-bold tracking-wider">{personalInfo.fullName}</h1>

--- a/components/resume/templates/MinimalistTemplate.tsx
+++ b/components/resume/templates/MinimalistTemplate.tsx
@@ -9,7 +9,7 @@ const MinimalistTemplate: React.FC<TemplateProps> = ({ data }) => {
     const { personalInfo, summary, experience, education, skills, projects, certifications, languages } = data;
 
     return (
-        <div className="h-full bg-white p-10 font-sans text-gray-700 text-sm leading-relaxed">
+        <div className="bg-white p-10 font-sans text-gray-700 text-sm leading-relaxed">
             {/* Header */}
             <header className="mb-10">
                 <h1 className="text-4xl font-light tracking-wider uppercase">{personalInfo.fullName}</h1>

--- a/components/resume/templates/ModernTemplate.tsx
+++ b/components/resume/templates/ModernTemplate.tsx
@@ -9,7 +9,7 @@ const ModernTemplate: React.FC<TemplateProps> = ({ data }) => {
     const { personalInfo, summary, experience, education, skills, projects, certifications, languages } = data;
 
     return (
-        <div className="h-full flex font-sans bg-white text-gray-800 text-sm">
+        <div className="flex font-sans bg-white text-gray-800 text-sm">
             {/* Left Column */}
             <aside className="w-1/3 bg-gray-100 p-8 text-gray-700">
                 <div className="text-center mb-10">

--- a/components/resume/templates/MonacoTemplate.tsx
+++ b/components/resume/templates/MonacoTemplate.tsx
@@ -19,7 +19,7 @@ const MonacoTemplate: React.FC<{ data: ResumeData }> = ({ data }) => {
     );
 
     return (
-        <div className="h-full flex font-sans bg-white text-gray-800 text-sm">
+        <div className="flex font-sans bg-white text-gray-800 text-sm">
             {/* Sidebar */}
             <aside className="w-1/3 bg-gray-50 p-6 flex flex-col">
                 <header className="text-left mb-10">

--- a/components/resume/templates/ProfessionalTemplate.tsx
+++ b/components/resume/templates/ProfessionalTemplate.tsx
@@ -12,7 +12,7 @@ const ProfessionalTemplate: React.FC<{ data: ResumeData }> = ({ data }) => {
     );
 
     return (
-        <div className="h-full bg-white font-sans text-gray-800 text-sm p-10">
+        <div className="bg-white font-sans text-gray-800 text-sm p-10">
             <header className="text-center mb-8">
                 <h1 className="text-4xl font-bold tracking-tight">{personalInfo.fullName}</h1>
                 <p className="text-xl font-medium text-gray-600 mt-1">{personalInfo.jobTitle}</p>

--- a/components/resume/templates/TechnicalTemplate.tsx
+++ b/components/resume/templates/TechnicalTemplate.tsx
@@ -16,7 +16,7 @@ const TechnicalTemplate: React.FC<TemplateProps> = ({ data }) => {
     );
 
     return (
-        <div className="h-full bg-white p-8 font-sans text-gray-800 text-sm leading-normal">
+        <div className="bg-white p-8 font-sans text-gray-800 text-sm leading-normal">
             {/* Header */}
             <header className="text-center mb-6">
                 <h1 className="text-3xl font-bold">{personalInfo.fullName}</h1>

--- a/pages/EditorPage.tsx
+++ b/pages/EditorPage.tsx
@@ -96,7 +96,7 @@ const EditorPage: React.FC = () => {
         document.body.appendChild(iframe);
 
         const iframeDoc = iframe.contentWindow!.document;
-        const resumeHTML = source.outerHTML;
+        const resumeHTML = source.innerHTML;
 
         // Hardcode the Tailwind script and config to ensure styles are applied reliably in the iframe.
         // This is the most robust way to handle printing across all browsers, especially mobile.
@@ -155,7 +155,7 @@ const EditorPage: React.FC = () => {
         iframeDoc.open();
         iframeDoc.write(printContent);
         iframeDoc.close();
-        
+
         const printAndCleanup = () => {
             try {
                 iframe.contentWindow!.focus(); // focus is important for some browsers
@@ -172,7 +172,7 @@ const EditorPage: React.FC = () => {
                 }, 1000);
             }
         };
-        
+
         // Use a longer timeout to ensure Tailwind's CDN script has time to fetch, run, and apply styles.
         setTimeout(printAndCleanup, 1000);
     };


### PR DESCRIPTION
This commit fixes a bug where downloaded resumes had extra space at the bottom and a scrollbar. The issues were caused by two problems:

1. The resume preview container's styles (overflow and max-height) were being included in the downloaded HTML. This was fixed by using `innerHTML` instead of `outerHTML` in the `handleDownload` function in `EditorPage.tsx`.

2. The root element of each resume template had a `h-full` class, which caused the resume to stretch to the height of its container. This was fixed by removing the `h-full` class from all 11 resume templates.

These changes ensure that the downloaded resume has a natural height based on its content, resulting in a clean and correctly formatted PDF.