### PR TITLE
feat: Scale resume to fit on a single page when downloading

### DIFF
--- a/pages/EditorPage.tsx
+++ b/pages/EditorPage.tsx
@@ -89,6 +89,10 @@ const EditorPage: React.FC = () => {
 
         setIsGenerating(true);
 
+        const contentHeight = source.scrollHeight;
+        const pageHeight = 1100; // 11 inches at 100dpi
+        const scale = contentHeight > pageHeight ? pageHeight / contentHeight : 1;
+
         const iframe = document.createElement('iframe');
         iframe.style.position = 'absolute';
         iframe.style.top = '-9999px';
@@ -147,7 +151,9 @@ const EditorPage: React.FC = () => {
                 </style>
               </head>
               <body>
-                ${resumeHTML}
+                 <div style="width: 850px; transform: scale(${scale}); transform-origin: top left;">
+                    ${resumeHTML}
+                </div>
               </body>
             </html>
         `;


### PR DESCRIPTION
This commit enhances the resume download functionality to ensure that the content always fits on a single page.

The `handleDownload` function in `pages/EditorPage.tsx` has been updated to:
1. Measure the scrollHeight of the resume content.
2. Calculate a scale factor to fit the content within a standard 11-inch page height.
3. Apply a `transform: scale()` CSS style to the resume HTML within the print iframe.

This prevents long resumes from spilling over into a second page and addresses the user's requirement for a "perfectly scaled" single-page resume.